### PR TITLE
fix capacity overflow error

### DIFF
--- a/src/gadgets/nonnative.rs
+++ b/src/gadgets/nonnative.rs
@@ -313,9 +313,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderNonNative<F, D>
     ) -> NonNativeTarget<FF> {
         let prod = self.add_virtual_nonnative_target::<FF>();
         let modulus = self.constant_biguint(&FF::order());
-        let overflow = self.add_virtual_biguint_target(
-            a.value.num_limbs() + b.value.num_limbs() - modulus.num_limbs(),
-        );
+        let overflow = self.add_virtual_biguint_target(modulus.num_limbs());
 
         self.add_simple_generator(NonNativeMultiplicationGenerator::<F, D, FF> {
             a: a.clone(),


### PR DESCRIPTION
The test `test_overflow` is failing due to the inappropriate handling of the limb count in the BigUint implementation. 

```rust

#[cfg(test)]
mod tests {
    use crate::gadgets::nonnative::CircuitBuilderNonNative;
    use plonky2::{
        field::{secp256k1_base::Secp256K1Base, types::Field},
        iop::witness::PartialWitness,
        plonk::{
            circuit_builder::CircuitBuilder,
            circuit_data::CircuitConfig,
            config::{GenericConfig, PoseidonGoldilocksConfig},
        },
    };

    #[test]
    fn test_overflow() {
        const D: usize = 2;
        type C = PoseidonGoldilocksConfig;
        type F = <C as GenericConfig<D>>::F;
        let config = CircuitConfig::standard_ecc_config();

        let pw = PartialWitness::<F>::new();
        let mut builder = CircuitBuilder::<F, D>::new(config);

        let a = Secp256K1Base::from_canonical_u32(1);
        let b = Secp256K1Base::from_canonical_u32(2);

        let a_t = builder.constant_nonnative(a);
        let b_t = builder.constant_nonnative(b);
        let _c_t = builder.mul_nonnative(&a_t, &b_t);

        let data = builder.build::<C>();
        let proof = data.prove(pw).unwrap();
        data.verify(proof).unwrap();
    }
}
```

Result
```bash
running 1 test
test tests::test_overflow ... FAILED

failures:

---- tests::test_overflow stdout ----
thread 'tests::test_overflow' panicked at 'capacity overflow', library/alloc/src/raw_vec.rs:525:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_overflow

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.00s
```