### PR TITLE
fix `NonNativeAdditionGenerator` bug

### DIFF
--- a/src/gadgets/nonnative.rs
+++ b/src/gadgets/nonnative.rs
@@ -475,7 +475,7 @@ impl<F: RichField + Extendable<D>, const D: usize, FF: PrimeField> SimpleGenerat
         let b_biguint = b.to_canonical_biguint();
         let sum_biguint = a_biguint + b_biguint;
         let modulus = FF::order();
-        let (overflow, sum_reduced) = if sum_biguint > modulus {
+        let (overflow, sum_reduced) = if sum_biguint >= modulus {
             (true, sum_biguint - modulus)
         } else {
             (false, sum_biguint)


### PR DESCRIPTION
The `NonNativeAdditionGenerator` does not take into account the case when `a + b = modulus`.

For example, the following test will fail:

```rust
#[cfg(test)]
mod tests {
    use crate::gadgets::nonnative::CircuitBuilderNonNative;
    use plonky2::{
        field::{secp256k1_base::Secp256K1Base, types::Field},
        iop::witness::PartialWitness,
        plonk::{
            circuit_builder::CircuitBuilder,
            circuit_data::CircuitConfig,
            config::{GenericConfig, PoseidonGoldilocksConfig},
        },
    };

    #[test]
    fn test_add_to_zero() {
        const D: usize = 2;
        type C = PoseidonGoldilocksConfig;
        type F = <C as GenericConfig<D>>::F;
        let config = CircuitConfig::standard_ecc_config();

        let pw = PartialWitness::<F>::new();
        let mut builder = CircuitBuilder::<F, D>::new(config);

        let a = Secp256K1Base::ONE;
        let b = Secp256K1Base::NEG_ONE;

        let a_t = builder.constant_nonnative(a);
        let b_t = builder.constant_nonnative(b);
        let c_t = builder.add_nonnative(&a_t, &b_t);

        let zero_t = builder.constant_nonnative(Secp256K1Base::ZERO);

        builder.connect_nonnative(&c_t, &zero_t);

        let data = builder.build::<C>();
        let proof = data.prove(pw).unwrap();
        data.verify(proof).unwrap();
    }
}
```