### PR TITLE
adds serialization/deserialization methods needed for simple generator trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ itertools = { version = "0.10.0", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }
 num = { version = "0.4.0", default-features = false }
 plonky2 = { version = "0.1.2", default-features = false }
-plonky2_u32 = { version = "0.1.0", default-features = false }
+plonky2_u32 = { git = "https://github.com/mir-protocol/plonky2-u32" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = { version = "1.0.40", default-features = false }
 itertools = { version = "0.10.0", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }
 num = { version = "0.4.0", default-features = false }
-plonky2 = { version = "0.1.2", default-features = false }
+plonky2 = { version = "0.1.4", default-features = false }
 plonky2_u32 = { git = "https://github.com/mir-protocol/plonky2-u32" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,5 @@ extern crate alloc;
 
 pub mod curve;
 pub mod gadgets;
+
+mod serialization;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use plonky2::util::serialization::{Buffer, IoResult, Write};
+use plonky2::util::serialization::{Buffer, IoResult, Read, Write};
 use plonky2_u32::serialization::{ReadU32, WriteU32};
 
 use crate::gadgets::biguint::BigUintTarget;
@@ -18,6 +18,7 @@ impl WriteBigUintTarget for Vec<u8> {
         for limb in &biguint_target.limbs {
             self.write_target_u32(*limb)?;
         }
+
         Ok(())
     }
 }
@@ -28,8 +29,9 @@ pub trait ReadBigUintTarget {
 
 impl ReadBigUintTarget for Buffer<'_> {
     fn read_biguint_target(&mut self) -> IoResult<BigUintTarget> {
-        let mut num_limbs_be = [0_u8; 8];
-        num_limbs_be.copy_from_slice(&self.bytes()[0..8]);
+        let mut num_limbs_be = [0_u8; core::mem::size_of::<usize>()];
+
+        self.read_exact(&mut num_limbs_be)?;
 
         let num_limbs = usize::from_be_bytes(num_limbs_be);
         let mut limbs = Vec::new();
@@ -40,5 +42,48 @@ impl ReadBigUintTarget for Buffer<'_> {
         }
 
         Ok(BigUintTarget { limbs })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::iop::{target::Target, wire::Wire};
+    use plonky2_u32::gadgets::arithmetic_u32::U32Target;
+
+    use super::*;
+
+    #[test]
+    fn test_read_write_biguint_target() {
+        let biguint_target = BigUintTarget {
+            limbs: vec![
+                U32Target(Target::VirtualTarget { index: 0 }),
+                U32Target(Target::Wire(Wire { row: 0, column: 0 })),
+            ],
+        };
+        let mut buff = vec![];
+        buff.write_biguint_target(biguint_target.clone())
+            .expect("Failed to write `BigUintTarget`");
+
+        let mut len_bytes = [0u8; core::mem::size_of::<usize>()];
+        len_bytes.copy_from_slice(&buff[0..core::mem::size_of::<usize>()]);
+        assert_eq!(usize::from_be_bytes(len_bytes), 2);
+
+        let mut buff = Buffer::new(&buff);
+        let expected_biguint_target = buff
+            .read_biguint_target()
+            .expect("Failed to read `BigUintTarget`");
+
+        assert_eq!(
+            biguint_target.limbs.len(),
+            expected_biguint_target.limbs.len()
+        );
+
+        for (limb, expected_limb) in biguint_target
+            .limbs
+            .iter()
+            .zip(expected_biguint_target.limbs)
+        {
+            assert_eq!(limb.0, expected_limb.0);
+        }
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,44 @@
+use alloc::vec::Vec;
+use plonky2::util::serialization::{Buffer, IoResult, Write};
+use plonky2_u32::serialization::{ReadU32, WriteU32};
+
+use crate::gadgets::biguint::BigUintTarget;
+
+pub trait WriteBigUintTarget {
+    fn write_biguint_target(&mut self, biguint_target: BigUintTarget) -> IoResult<()>;
+}
+
+impl WriteBigUintTarget for Vec<u8> {
+    fn write_biguint_target(&mut self, biguint_target: BigUintTarget) -> IoResult<()> {
+        let num_limbs = biguint_target.num_limbs();
+        let num_limbs_be = num_limbs.to_be_bytes();
+        for byte in &num_limbs_be {
+            self.write_u8(*byte)?
+        }
+        for limb in &biguint_target.limbs {
+            self.write_target_u32(*limb)?;
+        }
+        Ok(())
+    }
+}
+
+pub trait ReadBigUintTarget {
+    fn read_biguint_target(&mut self) -> IoResult<BigUintTarget>;
+}
+
+impl ReadBigUintTarget for Buffer<'_> {
+    fn read_biguint_target(&mut self) -> IoResult<BigUintTarget> {
+        let mut num_limbs_be = [0_u8; 8];
+        num_limbs_be.copy_from_slice(&self.bytes()[0..8]);
+
+        let num_limbs = usize::from_be_bytes(num_limbs_be);
+        let mut limbs = Vec::new();
+
+        for _ in 0..num_limbs {
+            let limb = self.read_target_u32()?;
+            limbs.push(limb)
+        }
+
+        Ok(BigUintTarget { limbs })
+    }
+}


### PR DESCRIPTION
Currently, the library does not compile due to incompatibilities with the latest plonky2 head. We implement deserialization/serialization for the necessary structs, in order to resolve this.

Notice that a nice solution for this problem has already been proposed in PR #3 . We decided to add the current one for potential completion.