### PR TITLE
fix: set correct overflow range

### DIFF
--- a/src/gadgets/nonnative.rs
+++ b/src/gadgets/nonnative.rs
@@ -475,7 +475,7 @@ impl<F: RichField + Extendable<D>, const D: usize, FF: PrimeField> SimpleGenerat
         let b_biguint = b.to_canonical_biguint();
         let sum_biguint = a_biguint + b_biguint;
         let modulus = FF::order();
-        let (overflow, sum_reduced) = if sum_biguint > modulus {
+        let (overflow, sum_reduced) = if sum_biguint >= modulus {
             (true, sum_biguint - modulus)
         } else {
             (false, sum_biguint)


### PR DESCRIPTION
## Description
This PR fixes the `NonNativeAddition` to subtract the modulus when the sum is equal to the modulus.

There is a bug where the sum is equal to the modulus but not subtracted, so they might be recognized as different when comparing the result of the addition and zero in limbs.